### PR TITLE
Rename libMidgard overlay to default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   in {
       inherit midgardOverlay mapMidgardOverlay;
 
-      overlays.libMidgard = midgardOverlay (final: prev: let
+      overlays.default = midgardOverlay (final: prev: let
         inherit (prev.lib) mapAttrs' nameValuePair removeSuffix foldAttrs;
       in {
         lib = {


### PR DESCRIPTION
Forslag:
- Rename libMidgard overlay to default
- [x] Rename repo to `midgard-lib` for å repesisere at dette bare er lib funksjoner som lever i pkgs.midgard.lib.